### PR TITLE
Allow scroll to top and bottom with <Up> & <Down>

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -81,8 +81,23 @@ function! peekaboo#peek(count, mode, visualmode)
   redraw
 
   try
-    let reg  = nr2char(getchar())
+    let reg  = getchar()
     let rest = ''
+
+    while reg == "\<Down>" || reg == "\<Up>"
+        wincmd p
+        if reg == "\<Down>"
+            execute 'normal! G'
+        else
+            execute 'normal! gg'
+        endif
+        wincmd p
+        redraw
+        let reg = getchar()
+    endwhile
+
+    let reg = nr2char(reg)
+
     if a:mode ==# 'quote' && has_key(s:regs, tolower(reg))
       wincmd p
       let line = s:regs[tolower(reg)]


### PR DESCRIPTION
If the window is too small then not all named registers can be inspected.  This PR allows the peekaboo window to be scrolled to the top and bottom using <Up> and <Down>.  I don't have huge experience with writing plugins, so this may not be the best way to achieve this functionality though!...