### PR TITLE
Fix #11 #12 - Temporarily disable mappings during replay

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -101,9 +101,11 @@ function! s:feed(count, mode, reg, rest)
     else                 | let seq .= "\<Plug>(pkbcr)" . a:reg
     endif
   else
+    call peekaboo#off()
     if a:reg == '@' | let seq .= "\<Plug>(pkbr2)" . a:rest
     else            | let seq .= "\<Plug>(pkbr1)" . a:reg . a:rest
     endif
+    let seq .= "\<Plug>(pkbon)"
   endif
   call feedkeys(seq)
 endfunction
@@ -188,6 +190,10 @@ xnoremap <Plug>(pkbq2) ""
 nnoremap <Plug>(pkbr1) @
 nnoremap <Plug>(pkbr2) @@
 inoremap <Plug>(pkbcr) <c-r>
+nnoremap <silent> <Plug>(pkbon) :call peekaboo#on()<cr>
+inoremap <silent> <Plug>(pkbon) <c-o>:call peekaboo#on()<cr>
+vnoremap <silent> <Plug>(pkbon) :<c-u>call peekaboo#on()<cr>gv
+cnoremap <silent> <Plug>(pkbon) <c-r>=peekaboo#on()<cr>
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/plugin/peekaboo.vim
+++ b/plugin/peekaboo.vim
@@ -20,8 +20,20 @@
 " OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 " THE SOFTWARE.
 
-nnoremap <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  0)<cr>
-xnoremap <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  1)<cr>
-nnoremap <silent> @ :<c-u>call peekaboo#peek(v:count1, 'replay', 0)<cr>
-inoremap <silent> <c-r> <c-o>:call peekaboo#peek(1, 'ctrl-r',  0)<cr>
+function! peekaboo#on()
+  nnoremap <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  0)<cr>
+  xnoremap <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  1)<cr>
+  nnoremap <silent> @ :<c-u>call peekaboo#peek(v:count1, 'replay', 0)<cr>
+  inoremap <silent> <c-r> <c-o>:call peekaboo#peek(1, 'ctrl-r',  0)<cr>
+  return ''
+endfunction
+
+function! peekaboo#off()
+  nunmap "
+  xunmap "
+  nunmap @
+  iunmap <c-r>
+endfunction
+
+call peekaboo#on()
 


### PR DESCRIPTION
`feedkeys()` doesn't work as expected when called during macro replay. This commit temporarily disables peekaboo mappings so that peekaboo doesn't get in the way. Expected to fix #11 and #12.

/cc @nicolaiskogheim