### PR TITLE
Don't trigger autocmds when switching back

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -115,7 +115,7 @@ function! s:init(mode)
 endfunction
 
 function! s:back(visualmode)
-  execute s:win.current.'wincmd w'
+  noautocmd execute s:win.current.'wincmd w'
   if a:visualmode
     normal! gv
   endif


### PR DESCRIPTION
The peekabook window should be as unintrusive as possible. The buffer in the
source window shouldn't be changed in the first place, therefore there is no
need to retrigger any autocmds when switching back to it.

---

Hi,

I noticed this glitch because whenever I enter a help buffer, either `wincmd L` (if there's only window) or `wincmd T` (all other cases) gets triggered.

Thus `:h :h` creates a vertical split and the time I press <kbd>"</kbd>, `peekaboo#peek()` runs `s:back()`, where `execute s:win.current.'wincmd w'` goes back to the source window which triggers `wincmd T`, which creates a new tab, which is not what I expect.