### PR TITLE
Add key map prefix customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ let g:peekaboo_delay = 750
 
 " Compact display; do not display the names of the register groups
 let g:peekaboo_compact = 1
+
+" Prefix for the peekaboo key mapping (default: '')
+let g:peekaboo_prefix = '<leader>'
+
+" Prefix for CTRL-R insert key mapping (default: '')
+let g:peekaboo_ins_prefix = '<c-x>'
 ```
 
 FAQ

--- a/plugin/peekaboo.vim
+++ b/plugin/peekaboo.vim
@@ -24,19 +24,24 @@ function! peekaboo#on()
   if get(b:, 'peekaboo_on', 0)
     return
   endif
-  nnoremap <buffer> <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  0)<cr>
-  xnoremap <buffer> <silent> " :<c-u>call peekaboo#peek(v:count1, 'quote',  1)<cr>
-  nnoremap <buffer> <silent> @ :<c-u>call peekaboo#peek(v:count1, 'replay', 0)<cr>
-  inoremap <buffer> <silent> <c-r> <c-o>:call peekaboo#peek(1, 'ctrl-r',  0)<cr>
+
+  let prefix = get(g:, 'peekaboo_prefix', '')
+  let ins_prefix = get(g:, 'peekaboo_ins_prefix', '')
+  execute 'nnoremap <buffer> <silent> '.prefix.'" :<c-u>call peekaboo#peek(v:count1, ''quote'',  0)<cr>'
+  execute 'xnoremap <buffer> <silent> '.prefix.'" :<c-u>call peekaboo#peek(v:count1, ''quote'',  1)<cr>'
+  execute 'nnoremap <buffer> <silent> '.prefix.'@ :<c-u>call peekaboo#peek(v:count1, ''replay'', 0)<cr>'
+  execute 'inoremap <buffer> <silent> '.ins_prefix.'<c-r> <c-o>:call peekaboo#peek(1, ''ctrl-r'',  0)<cr>'
   let b:peekaboo_on = 1
   return ''
 endfunction
 
 function! peekaboo#off()
-  nunmap <buffer> "
-  xunmap <buffer> "
-  nunmap <buffer> @
-  iunmap <buffer> <c-r>
+  let prefix = get(g:, 'peekaboo_prefix', '')
+  let ins_prefix = get(g:, 'peekaboo_ins_prefix', '')
+  execute 'nunmap <buffer> '.prefix.'"'
+  execute 'xunmap <buffer> '.prefix.'"'
+  execute 'nunmap <buffer> '.prefix.'@'
+  execute 'iunmap <buffer> '.ins_prefix.'<c-r>'
   let b:peekaboo_on = 0
 endfunction
 


### PR DESCRIPTION
This would allow users to optionally toggle peekaboo with a custom prefix when they feel they need it. I think it would also be an acceptable alternative way to use the plugin for people having problems with macros and recursive `normal` commands ([as noted in a comment on SE][1]).

I originally wanted to have a single setting for the prefix with `<c-x>` as a suggestion in the README, but that would override the default `<c-x>` in normal/visual mode and using anything but a `ctrl` prefix in insert mode is just weird.

I think the `FAQ` and `Known Issues` would need to be updated, but I didn't want to change the tone of your README.

[1]: http://vi.stackexchange.com/a/8471/5229