### PR TITLE
Add support for <CTRL-W>" in terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ vim-peekaboo
 
 ![](https://cloud.githubusercontent.com/assets/700826/6095261/bb00340c-af96-11e4-9df5-9cd869673a11.gif)
 
-Peekaboo extends `"` and `@` in normal mode and `<CTRL-R>` in insert mode so
-you can see the contents of the registers.
+Peekaboo extends `"` and `@` in normal mode, `<CTRL-R>` in insert mode and
+`<CTRL-W>"` in Terminal-Job mode so you can see the contents of the registers.
 
 Installation
 ------------
@@ -19,8 +19,9 @@ Usage
 -----
 
 Peekaboo will show you the contents of the registers on the sidebar when you
-hit `"` or `@` in normal mode or `<CTRL-R>` in insert mode. The sidebar is
-automatically closed on subsequent key strokes.
+hit `"` or `@` in normal mode, `<CTRL-R>` in insert mode or `<CTRL-W>"` in
+Terminal-Job mode. The sidebar is automatically closed on subsequent key
+strokes.
 
 You can toggle fullscreen mode by pressing spacebar.
 

--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -31,6 +31,7 @@ let s:default_compact = 0
 let s:QUOTE  = '"'
 let s:REPLAY = '@'
 let s:CTRL_R = "\<c-r>"
+let s:TERM = "\<c-w>\""
 
 let s:buf_peekaboo = 0
 
@@ -132,6 +133,8 @@ function! s:feed(count, mode, reg, rest)
     call feedkeys(a:rest)
   elseif a:mode ==# s:CTRL_R
     call feedkeys("\<c-r>".a:reg, 'n')
+  elseif a:mode ==# s:TERM
+    call feedkeys("\<c-w>\"".a:reg, 'n')
   else
     call feedkeys('@'.a:reg, 'n')
   endif

--- a/plugin/peekaboo.vim
+++ b/plugin/peekaboo.vim
@@ -23,6 +23,9 @@
 nnoremap <silent> <Plug>(peekaboo) :<c-u>call peekaboo#aboo()<cr>
 xnoremap <silent> <Plug>(peekaboo) :<c-u>call peekaboo#aboo()<cr>
 inoremap <silent> <Plug>(peekaboo) <c-\><c-o>:<c-u>call peekaboo#aboo()<cr>
+if exists(':tnoremap')
+   tnoremap <silent> <Plug>(peekaboo) <c-w>:call peekaboo#aboo()<cr>
+endif
 
 function! peekaboo#on()
   if get(b:, 'peekaboo_on', 0)
@@ -31,10 +34,13 @@ function! peekaboo#on()
 
   let prefix = get(g:, 'peekaboo_prefix', '')
   let ins_prefix = get(g:, 'peekaboo_ins_prefix', '')
-  execute 'nmap <buffer> <expr> '.prefix.    '"     peekaboo#peek(v:count1, ''"'',  0)'
-  execute 'xmap <buffer> <expr> '.prefix.    '"     peekaboo#peek(v:count1, ''"'',  1)'
-  execute 'nmap <buffer> <expr> '.prefix.    '@     peekaboo#peek(v:count1, ''@'', 0)'
-  execute 'imap <buffer> <expr> '.ins_prefix.'<c-r> peekaboo#peek(1, "\<c-r>",  0)'
+  execute 'nmap <buffer> <expr> '.prefix.    '"      peekaboo#peek(v:count1, ''"'',  0)'
+  execute 'xmap <buffer> <expr> '.prefix.    '"      peekaboo#peek(v:count1, ''"'',  1)'
+  execute 'nmap <buffer> <expr> '.prefix.    '@      peekaboo#peek(v:count1, ''@'', 0)'
+  execute 'imap <buffer> <expr> '.ins_prefix.'<c-r>  peekaboo#peek(1, "\<c-r>",  0)'
+   if exists(':tmap')
+     execute 'tmap <buffer> <expr> '.prefix.    '<c-w>" peekaboo#peek(1, "\<c-w>\"",  1)'
+   endif
   let b:peekaboo_on = 1
   return ''
 endfunction


### PR DESCRIPTION
This way the sidebar presenting the registers is openend when using `<CTRL-W>"` to paste in terminal mode.