### PR TITLE
Restore alternate buffer

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -58,7 +58,9 @@ endfunction
 function! s:close()
   silent! execute 'bd' s:buf_peekaboo
   let s:buf_peekaboo = 0
-  let @# = s:buf_alternate
+  if s:alternate != ''
+    let @# = s:buf_alternate
+  endif
   execute s:winrestcmd
 endfunction
 


### PR DESCRIPTION
This ensures that the alternate buffer is restored after closing the peekaboo window. Without this change and if `peekaboo_window = 'enew'`, the content of the buffer is lost.