### PR TITLE
Fix bug with Zoom -> Unzoom

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -194,6 +194,7 @@ function! peekaboo#aboo()
 
       if zoom
         tab close
+        noautocmd execute 'tabnext' positions.current.tab
         let [&showtabline, &laststatus] = [stl, lst]
         call s:gv(visualmode, visible)
       endif


### PR DESCRIPTION
This fixes the following bug:

If the vim session contains two tabs, and the focus is on the first one, `"<Space><Spaces>` will bring the focus to the second tab.