### PR TITLE
don't fire autocmds when switching windows

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -115,10 +115,10 @@ endfunction
 " Triggers gv to keep visual highlight on
 function! s:gv(visualmode, visible)
   if a:visualmode && a:visible
-    wincmd p
+    noautocmd wincmd p
     normal! gv
     redraw
-    wincmd p
+    noautocmd wincmd p
   else
     redraw
   endif


### PR DESCRIPTION
Apparently, [Neovim now fires the `CursorMoved` autocmd every time a window is changed](https://github.com/neovim/neovim/blob/master/runtime/doc/autocmd.txt#L647), and that seems to be the root cause of the problem I ran into in #61. (More details can be found in https://github.com/neovim/neovim/issues/11102.) This change has fixed that specific issue for me, but I don't know if there might be other problematic side effects.