### PR TITLE
make display of special and read-only registers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ You can toggle fullscreen mode by pressing spacebar.
 Customization
 -------------
 
-| Config                  | Default         | Description                                       |
-| ------                  | -------         | -----------                                       |
-| `g:peekaboo_window`     | `vert bo 30new` | Command for creating Peekaboo window              |
-| `g:peekaboo_delay`      | 0 (ms)          | Delay opening of Peekaboo window                  |
-| `g:peekaboo_compact`    | 0 (boolean)     | Compact display                                   |
-| `g:peekaboo_prefix`     | Empty (string)  | Prefix for key mapping (e.g. `<leader>`)          |
-| `g:peekaboo_ins_prefix` | Empty (string)  | Prefix for insert mode key mapping (e.g. `<c-x>`) |
+| Config                  | Default                 | Description                                       |
+| ------                  | -------                 | -----------                                       |
+| `g:peekaboo_window`     | `vert bo 30new`         | Command for creating Peekaboo window              |
+| `g:peekaboo_delay`      | 0 (ms)                  | Delay opening of Peekaboo window                  |
+| `g:peekaboo_compact`    | 0 (boolean)             | Compact display                                   |
+| `g:peekaboo_prefix`     | Empty (string)          | Prefix for key mapping (e.g. `<leader>`)          |
+| `g:peekaboo_ins_prefix` | Empty (string)          | Prefix for insert mode key mapping (e.g. `<c-x>`) |
+| `g:peekaboo_special`    | '"', '*', '+', '-'      | Special registers to be listed                    |
+| `g:peekaboo_readonly`   | '.', '%', '#', '/', ':' | Read-only registers to be listed                  |
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ You can toggle fullscreen mode by pressing spacebar.
 Customization
 -------------
 
-| Config                  | Default                 | Description                                       |
-| ------                  | -------                 | -----------                                       |
-| `g:peekaboo_window`     | `vert bo 30new`         | Command for creating Peekaboo window              |
-| `g:peekaboo_delay`      | 0 (ms)                  | Delay opening of Peekaboo window                  |
-| `g:peekaboo_compact`    | 0 (boolean)             | Compact display                                   |
-| `g:peekaboo_prefix`     | Empty (string)          | Prefix for key mapping (e.g. `<leader>`)          |
-| `g:peekaboo_ins_prefix` | Empty (string)          | Prefix for insert mode key mapping (e.g. `<c-x>`) |
-| `g:peekaboo_special`    | '"', '*', '+', '-'      | Special registers to be listed                    |
-| `g:peekaboo_readonly`   | '.', '%', '#', '/', ':' | Read-only registers to be listed                  |
+| Config                  | Default                     | Description                                       |
+| ------                  | -------                     | -----------                                       |
+| `g:peekaboo_window`     | `vert bo 30new`             | Command for creating Peekaboo window              |
+| `g:peekaboo_delay`      | 0 (ms)                      | Delay opening of Peekaboo window                  |
+| `j:peekaboo_compact`    | 0 (boolean)                 | Compact display                                   |
+| `g:peekaboo_prefix`     | Empty (string)              | Prefix for key mapping (e.g. `<leader>`)          |
+| `g:peekaboo_ins_prefix` | Empty (string)              | Prefix for insert mode key mapping (e.g. `<c-x>`) |
+| `g:peekaboo_special`    | `['"', '*', '+', '-']`      | Special registers to be listed                    |
+| `g:peekaboo_readonly`   | `['.', '%', '#', '/', ':']` | Read-only registers to be listed                  |
 
 License
 -------

--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -100,8 +100,8 @@ function! s:open(mode)
   augroup END
 
   let s:regs = {}
-  call s:append_group('Special', ['"', '*', '+', '-'])
-  call s:append_group('Read-only', a:mode ==# s:REPLAY ? ['.', ':'] : ['.', '%', '#', '/', ':'])
+  call s:append_group('Special', get(g:, 'peekaboo_special', ['"', '*', '+', '-']))
+  call s:append_group('Read-only', a:mode ==# s:REPLAY ? ['.', ':'] : get(g:, 'peekaboo_readonly', ['.', '%', '#', '/', ':']))
   call s:append_group('Numbered', map(range(0, 9), 'string(v:val)'))
   call s:append_group('Named', map(range(97, 97 + 25), 'nr2char(v:val)'))
   normal! "_dd

--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -64,7 +64,7 @@ endfunction
 " Appends macro list for the specified group to Peekaboo window
 function! s:append_group(title, regs)
   let compact = get(g:, 'peekaboo_compact', s:default_compact)
-  if !compact | call append(line('$'), a:title.':') | endif
+  if !compact && !empty(a:regs) | call append(line('$'), a:title.':') | endif
   for r in a:regs
     try
       if r == '%'     | let val = s:buf_current

--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -63,8 +63,11 @@ endfunction
 
 " Appends macro list for the specified group to Peekaboo window
 function! s:append_group(title, regs)
+  if empty(a:regs)
+    return
+  endif
   let compact = get(g:, 'peekaboo_compact', s:default_compact)
-  if !compact && !empty(a:regs) | call append(line('$'), a:title.':') | endif
+  if !compact | call append(line('$'), a:title.':') | endif
   for r in a:regs
     try
       if r == '%'     | let val = s:buf_current


### PR DESCRIPTION
For example, `-` is of little use and `"` probably not of interest. 