### PR TITLE
foldcolumn independent window #77

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -167,6 +167,9 @@ function! peekaboo#aboo()
   if s:is_open()
     call s:close()
   endif
+  
+  let g:foldcolumn_orig=&foldcolumn " at EO-func restore original
+  set foldcolumn=0  " so peekaboo vsplit has it too
 
   let positions = { 'current': s:getpos() }
   call s:open(mode)
@@ -239,6 +242,8 @@ function! peekaboo#aboo()
     let [&showtabline, &laststatus] = [stl, lst]
     call s:close()
     redraw
+    " restore with window foldcolumn
+    exec 'set foldcolumn='.g:foldcolumn_orig
   endtry
 endfunction
 


### PR DESCRIPTION
See issue: https://github.com/junegunn/vim-peekaboo/issues/77
Maybe a would be clearer, instead o this commit, a python-wrapper-decorator for Vim. Like I dirty proposed in issue.
Note: g:foldcolumn_orig global variable might be renamed to be more consistent with rest of plugin. Like: g:peekaboo#aboo#foldcolumn_orig
Note2: global variable (g:) maybe need correction to local function (l:) or to buffer (b:) or ... Idk.