### PR TITLE
Don't run winrestcmd to restore windows

### DIFF
--- a/autoload/peekaboo.vim
+++ b/autoload/peekaboo.vim
@@ -58,7 +58,6 @@ endfunction
 function! s:close()
   silent! execute 'bd' s:buf_peekaboo
   let s:buf_peekaboo = 0
-  execute s:winrestcmd
 endfunction
 
 " Appends macro list for the specified group to Peekaboo window
@@ -84,7 +83,7 @@ endfunction
 
 " Opens peekaboo window
 function! s:open(mode)
-  let [s:buf_current, s:buf_alternate, s:winrestcmd] = [@%, @#, winrestcmd()]
+  let [s:buf_current, s:buf_alternate] = [@%, @#]
   execute get(g:, 'peekaboo_window', s:default_window)
   let s:buf_peekaboo = bufnr('')
   setlocal nonumber buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap


### PR DESCRIPTION
---

#### Commits _(oldest to newest)_

3490bc6 Don't run winrestcmd to restore windows

If you look at `:h winrestcmd` it says:

```
winrestcmd()                                                      *winrestcmd()*
  Returns a sequence of |:resize| commands that should restore
  the current window sizes.  Only works properly when no windows
  are opened or closed and the current window and tab page is
  unchanged.
  Example: >vim
    let cmd = winrestcmd()
    call MessWithWindowSizes()
    exe cmd
```

We can't guarantee this, so don't try to restore windows.

Refs: https://github.com/neoclide/coc.nvim/issues/4178#issuecomment-1243592457
Refs: https://github.com/vim-ctrlspace/vim-ctrlspace/pull/306
Fixes: https://github.com/junegunn/vim-peekaboo/issues/74
Fixes: https://github.com/junegunn/vim-peekaboo/issues/83

<br/>